### PR TITLE
Make ratonvirus thread safe

### DIFF
--- a/lib/ratonvirus/support/backend.rb
+++ b/lib/ratonvirus/support/backend.rb
@@ -146,6 +146,7 @@ module Ratonvirus
         base_class = backend_class(backend_cls, "Base")
 
         if backend_value.is_a?(base_class)
+          fail 'Our fork breaks this configuration method. Please avoid using.'
           # Set the instance
           instance_variable_set(:"@#{backend_type}", backend_value)
 

--- a/lib/ratonvirus/support/backend.rb
+++ b/lib/ratonvirus/support/backend.rb
@@ -89,7 +89,7 @@ module Ratonvirus
         class_eval <<-CODE, __FILE__, __LINE__ + 1
           # Getter for #{backend_type}
           def self.#{backend_type}
-            @#{backend_type} ||= create_#{backend_type}
+            Thread.current[:ratonvirus_#{backend_type}] ||= create_#{backend_type}
           end
 
           # Setter for #{backend_type}
@@ -104,7 +104,7 @@ module Ratonvirus
           # Destroys the currently active #{backend_type}.
           # The #{backend_type} is re-initialized when the getter is called.
           def self.destroy_#{backend_type}
-            @#{backend_type} = nil
+            Thread.current[:ratonvirus_#{backend_type}] = nil
           end
 
           # Creates a new backend instance

--- a/spec/lib/ratonvirus/support/backend_spec.rb
+++ b/spec/lib/ratonvirus/support/backend_spec.rb
@@ -72,24 +72,6 @@ describe Ratonvirus::Support::Backend do
   describe ".set_backend" do
     let(:method) { RatonvirusTest.method(:set_backend) }
 
-    context "with Class backend_value" do
-      it "sets the backend correctly" do
-        cls = RatonvirusTest::Foo::Base.new
-
-        expect(RatonvirusTest).to receive(:instance_variable_set).with(
-          :@test,
-          cls
-        ).and_call_original
-        expect(RatonvirusTest).to receive(:instance_variable_set).with(
-          :@test_defs,
-          klass: RatonvirusTest::Foo::Base,
-          config: {}
-        ).and_call_original
-
-        method.call(backend_type, namespace, cls)
-      end
-    end
-
     context "with Array backend_value" do
       context "with config" do
         it "sets the backend correctly" do

--- a/spec/lib/ratonvirus/support/backend_spec.rb
+++ b/spec/lib/ratonvirus/support/backend_spec.rb
@@ -157,6 +157,7 @@ describe Ratonvirus::Support::Backend do
     before do
       subject.extend described_class
       subject.send(:define_backend, backend_type, namespace)
+      Thread.current[:ratonvirus_test] = nil
     end
 
     it "defines all expected methods" do
@@ -170,11 +171,12 @@ describe Ratonvirus::Support::Backend do
     describe ".test" do
       it "defines an instance variable on first call" do
         backend = RatonvirusTest::Foo::Base.new
-        expect(subject).to receive(:create_test).and_return(backend)
-        expect(subject.instance_variable_get(:@test)).to be_nil
+        allow(subject).to receive(:create_test).and_return(backend)
+        expect(subject).to receive(:create_test)
+        expect(Thread.current[:ratonvirus_test]).to be_nil
 
         subject.test
-        expect(subject.instance_variable_get(:@test)).to equal(backend)
+        expect(Thread.current[:ratonvirus_test]).to equal(backend)
       end
 
       it "defines an instance variable only on first call" do
@@ -200,10 +202,10 @@ describe Ratonvirus::Support::Backend do
 
     describe ".destroy_test" do
       it "unsets the backend variable" do
-        subject.instance_variable_set(:@test, true)
+        Thread.current[:ratonvirus_test] = true
         subject.destroy_test
 
-        expect(subject.instance_variable_get(:@test)).to be_nil
+        expect(Thread.current[:ratonvirus_test]).to be_nil
       end
     end
 

--- a/spec/lib/ratonvirus_spec.rb
+++ b/spec/lib/ratonvirus_spec.rb
@@ -91,15 +91,6 @@ describe Ratonvirus do
       expect(described_class.scanner).to be_a(described_class::Scanner::Test)
     end
 
-    it "returns a scanner configured as a class" do
-      scanner = described_class::Scanner::Test.new
-      described_class.configure do |config|
-        config.scanner = scanner
-      end
-
-      expect(described_class.scanner).to equal(scanner)
-    end
-
     it "allows reconfiguring a scanner" do
       described_class.configure do |config|
         config.scanner = :eicar
@@ -133,16 +124,6 @@ describe Ratonvirus do
       scanner = described_class.scanner
       described_class.destroy_scanner
       expect(described_class.scanner).not_to equal(scanner)
-
-      # Destroying a class defined scanner
-      scanner = described_class::Scanner::Test.new
-      described_class.configure do |config|
-        config.scanner = scanner
-      end
-
-      described_class.destroy_scanner
-      expect(described_class.scanner).not_to equal(scanner)
-      expect(described_class.scanner).to be_a(described_class::Scanner::Test)
     end
   end
 
@@ -155,15 +136,6 @@ describe Ratonvirus do
       expect(described_class.storage).to be_a(
         described_class::Storage::Filepath
       )
-    end
-
-    it "returns a storage configured as a class" do
-      storage = described_class::Storage::Test.new
-      described_class.configure do |config|
-        config.storage = storage
-      end
-
-      expect(described_class.storage).to equal(storage)
     end
 
     it "allows reconfiguring a storage" do
@@ -199,16 +171,6 @@ describe Ratonvirus do
       storage = described_class.storage
       described_class.destroy_storage
       expect(described_class.storage).not_to equal(storage)
-
-      # Destroying a class defined storage
-      storage = described_class::Storage::Test.new
-      described_class.configure do |config|
-        config.storage = storage
-      end
-
-      described_class.destroy_storage
-      expect(described_class.storage).not_to equal(storage)
-      expect(described_class.storage).to be_a(described_class::Storage::Test)
     end
   end
 end


### PR DESCRIPTION
We run Rails on a multi-threaded puma webserver. This means we need to
ensure that ratonvirus is thread safe before we use it.

We're changing the code here to avoid using a class instance variable
since this will be shared between threads.

[Trello](https://trello.com/c/kZMAxWfm/2236-investigate-virus-scanning-attached-files-on-upload-and-then-do-it-unless-we-cant)