### PR TITLE
Block file uploads if antivirus isn't available

### DIFF
--- a/app/validators/antivirus_validator.rb
+++ b/app/validators/antivirus_validator.rb
@@ -11,16 +11,19 @@ class AntivirusValidator < ActiveModel::EachValidator
 
     # Only scan if the scanner is available
     scanner = Ratonvirus.scanner
-    return unless scanner.available?
 
-    return unless scanner.virus?(value)
+    if scanner.available?
+      return unless scanner.virus?(value)
 
-    if scanner.errors.any?
-      scanner.errors.each do |err|
-        record.errors.add attribute, err
+      if scanner.errors.any?
+        scanner.errors.each do |err|
+          record.errors.add attribute, err
+        end
+      else
+        record.errors.add attribute, :antivirus_virus_detected
       end
     else
-      record.errors.add attribute, :antivirus_virus_detected
+      record.errors.add attribute, :antivirus_not_installed
     end
   end
 end

--- a/app/validators/antivirus_validator.rb
+++ b/app/validators/antivirus_validator.rb
@@ -22,7 +22,7 @@ class AntivirusValidator < ActiveModel::EachValidator
       else
         record.errors.add attribute, :antivirus_virus_detected
       end
-    else
+    elsif scanner.config[:force_availability]
       record.errors.add attribute, :antivirus_not_installed
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,3 +4,4 @@ en:
       antivirus_virus_detected: 'contains a virus'
       antivirus_client_error: 'could not be processed for virus scan'
       antivirus_file_not_found: 'could not be found for virus scan'
+      antivirus_not_installed: 'could not process the file. Please try again later.'

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -4,3 +4,4 @@ fi:
       antivirus_virus_detected: 'sisältää viruksen'
       antivirus_client_error: 'ei voitu käsitellä virustarkistusta varten'
       antivirus_file_not_found: 'ei ollut saatavilla virustarkistusta varten'
+      antivirus_not_installed: 'tiedostoa ei voitu käsitellä. Yritä uudelleen myöhemmin.'

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -4,3 +4,4 @@ sv:
       antivirus_virus_detected: 'innehåller ett virus'
       antivirus_client_error: 'kunde inte behandlas för virusskanning'
       antivirus_file_not_found: 'kunde inte hittas för virusskanning'
+      antivirus_not_installed: 'kunde inte bearbeta filen. Vänligen försök igen senare.'

--- a/lib/ratonvirus/scanner/base.rb
+++ b/lib/ratonvirus/scanner/base.rb
@@ -57,11 +57,7 @@ module Ratonvirus
       # This method can be overridden in the scanner implementations in case
       # the setup needs to be customized.
       def setup
-        if config[:force_availability]
-          @available = true
-        else
-          available?
-        end
+        available?
       end
 
       def available?

--- a/spec/lib/ratonvirus/scanner/base_spec.rb
+++ b/spec/lib/ratonvirus/scanner/base_spec.rb
@@ -29,33 +29,18 @@ describe Ratonvirus::Scanner::Base do
   end
 
   describe "#setup" do
-    context "when force_availability is true" do
-      let(:config) { { force_availability: true } }
+    it "sets availability to true when scanner is executable" do
+      expect(described_class).to receive(:executable?).and_return(true)
 
-      it "sets availability to true" do
-        expect(described_class).not_to receive(:executable?)
-
-        subject
-        expect(subject.available?).to be(true)
-      end
+      subject
+      expect(subject.available?).to be(true)
     end
 
-    context "when force_availability is false" do
-      let(:config) { { force_availability: false } }
+    it "sets availability to false when scanner is not executable" do
+      expect(described_class).to receive(:executable?).and_return(false)
 
-      it "sets availability to true when scanner is executable" do
-        expect(described_class).to receive(:executable?).and_return(true)
-
-        subject
-        expect(subject.available?).to be(true)
-      end
-
-      it "sets availability to false when scanner is not executable" do
-        expect(described_class).to receive(:executable?).and_return(false)
-
-        subject
-        expect(subject.available?).to be(false)
-      end
+      subject
+      expect(subject.available?).to be(false)
     end
   end
 

--- a/spec/validators/antivirus_validator_spec.rb
+++ b/spec/validators/antivirus_validator_spec.rb
@@ -61,11 +61,25 @@ describe AntivirusValidator do
         expect(scanner).not_to receive(:virus?)
       end
 
-      it "adds correct error message" do
-        expect(subject).not_to be_valid
-        expect(subject.errors[:file]).to contain_exactly(
-          "could not process the file. Please try again later."
-        )
+      context "with force_availability set to true" do
+        before do
+          expect(scanner).to receive(:config).and_return({ force_availability: true })
+        end
+
+        it "adds correct error message" do
+          expect(subject).not_to be_valid
+          expect(subject.errors[:file]).to contain_exactly(
+            "could not process the file. Please try again later."
+          )
+        end
+      end
+
+      context "with force_availability set to false" do
+        before do
+          expect(scanner).to receive(:config).and_return({ force_availability: false })
+        end
+
+        it { is_expected.to be_valid }
       end
     end
 

--- a/spec/validators/antivirus_validator_spec.rb
+++ b/spec/validators/antivirus_validator_spec.rb
@@ -61,7 +61,12 @@ describe AntivirusValidator do
         expect(scanner).not_to receive(:virus?)
       end
 
-      it { is_expected.to be_valid }
+      it "adds correct error message" do
+        expect(subject).not_to be_valid
+        expect(subject.errors[:file]).to contain_exactly(
+          "could not process the file. Please try again later."
+        )
+      end
     end
 
     context "with available scanner" do


### PR DESCRIPTION
The way we add the virus scanner to a rails app is by adding a validator to a model:

```
validates :file, antivirus: true
```

If clamav isn't available for scanning, it will [exit the validation process early][1] without throwing an error.

This means we'll be able to upload infected files if clamav is not running.

To put in a more stringent check, we are changing the validation process to throw an error if clamav is not available. If a user tries to upload a file while clamav is offline they will now be blocked from uploading.

[1]: https://github.com/futurelearn/ratonvirus/blob/9ece9882ff2f3507664411d5ad14fc39edb71e1d/app/validators/antivirus_validator.rb#L14

[Trello](https://trello.com/c/kZMAxWfm/2236-investigate-virus-scanning-attached-files-on-upload-and-then-do-it-unless-we-cant)