### PR TITLE
Skip validation if we don't expect the antivirus to be present

### DIFF
--- a/app/validators/antivirus_validator.rb
+++ b/app/validators/antivirus_validator.rb
@@ -9,8 +9,9 @@ class AntivirusValidator < ActiveModel::EachValidator
     return unless storage.accept?(value)
     return unless storage.changed?(record, attribute)
 
-    # Only scan if the scanner is available
+    # Only scan if we expect the antivirus to be running, e.g. non-development environments
     scanner = Ratonvirus.scanner
+    return unless scanner.config[:force_availability]
 
     if scanner.available?
       return unless scanner.virus?(value)
@@ -22,7 +23,7 @@ class AntivirusValidator < ActiveModel::EachValidator
       else
         record.errors.add attribute, :antivirus_virus_detected
       end
-    elsif scanner.config[:force_availability]
+    else
       record.errors.add attribute, :antivirus_not_installed
     end
   end

--- a/lib/ratonvirus/scanner/base.rb
+++ b/lib/ratonvirus/scanner/base.rb
@@ -113,7 +113,7 @@ module Ratonvirus
       protected
 
       def default_config
-        { force_availability: false }
+        { force_availability: true }
       end
 
       def storage

--- a/spec/lib/ratonvirus/scanner/base_spec.rb
+++ b/spec/lib/ratonvirus/scanner/base_spec.rb
@@ -62,7 +62,7 @@ describe Ratonvirus::Scanner::Base do
 
   describe "#default_config" do
     let(:defaults) { subject.send(:default_config) }
-    let(:expected) { { force_availability: false } }
+    let(:expected) { { force_availability: true } }
 
     it "has default configuration" do
       expect(subject.config).to include(defaults)

--- a/spec/validators/antivirus_validator_spec.rb
+++ b/spec/validators/antivirus_validator_spec.rb
@@ -22,6 +22,12 @@ describe AntivirusValidator do
   end
   let(:subject) { validatable.new }
   let(:storage) { double }
+  let(:scanner) { double }
+
+  before do
+    allow(scanner).to receive(:config).and_return({ force_availability: true })
+    allow(Ratonvirus).to receive(:scanner).and_return(scanner).ordered
+  end
 
   context "when storage does not accept the resource" do
     before do
@@ -46,24 +52,21 @@ describe AntivirusValidator do
   end
 
   context "when file is changed and accepted" do
-    let(:scanner) { double }
-
     before do
       expect(Ratonvirus).to receive(:storage).and_return(storage).ordered
       expect(storage).to receive(:accept?).and_return(true).ordered
       expect(storage).to receive(:changed?).and_return(true).ordered
-      expect(Ratonvirus).to receive(:scanner).and_return(scanner).ordered
+
     end
 
     context "with unavailable scanner" do
       before do
-        expect(scanner).to receive(:available?).and_return(false).ordered
         expect(scanner).not_to receive(:virus?)
       end
 
       context "with force_availability set to true" do
         before do
-          expect(scanner).to receive(:config).and_return({ force_availability: true })
+          expect(scanner).to receive(:available?).and_return(false).ordered
         end
 
         it "adds correct error message" do


### PR DESCRIPTION
We'd like to allow developers to upload files in development without
expecting them to install Clamav.

[We initially assumed][1] that `scanner.available?` will return `false` since
Clamav won't be installed locally. However, calling `available?`
just checks that `Ratonvirus::Clamby::Base` is an executable class
(which is always true because it's a class present in the
ratonvirus-clamby gem). The scan will therefore still be run locally but
will fail when it doesn't find an antivirus.

So we'd actually block people from uploading when running in development
because it looks like the scanner is available.

We've used `force_availability` as a feature flag to indicate whether we
expect an antivirus to be present. Let's return early in the validation
class without scanning when we set `force_availability` to `false`.

This means we can now upload to our heart's content in development, but
still expect the antivirus to be present everywhere else.

While we're here we'd like to make sure that we expect the antivirus to 
be present by default. In case we ever set up a new environment (pentest, 
disaster recovery), we won't need to worry about setting this to `true` in
the config. By default we'll expect an antivirus to be installed or we raise 
an error.

[Trello](https://trello.com/c/kZMAxWfm/2236-investigate-virus-scanning-attached-files-on-upload-and-then-do-it-unless-we-cant)

[1]: https://github.com/futurelearn/ratonvirus/commit/3330d91f60b522853bd2c4099b707bfdb28561ed